### PR TITLE
fix(query):remove author id, no such field

### DIFF
--- a/issue.js
+++ b/issue.js
@@ -28,7 +28,6 @@ const IssueCommentsQuery = gql`
               id
               body
               author {
-                id
                 login
               }
             }


### PR DESCRIPTION
Author type have only three fields: avatarURL, login, path.
while it implements User and Bot, 
if really want author.id, fragment query is needed here
but it is not used in code, so removed.